### PR TITLE
18662 test

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -22,6 +22,7 @@ frr_northbound*
 /lib/cli/test_commands
 /lib/cli/test_commands_defun.c
 /lib/northbound/test_oper_data
+/lib/northbound/test_oper_exists
 /lib/cxxcompat
 /lib/fuzz_zlog
 /lib/test_assert

--- a/tests/lib/northbound/test_oper_data.c
+++ b/tests/lib/northbound/test_oper_data.c
@@ -249,9 +249,10 @@ static enum nb_error frr_test_module_c2cont_c2value_get(const struct nb_node *nb
 							struct lyd_node *parent)
 {
 	const struct lysc_node *snode = nb_node->snode;
-	uint32_t value = 0xAB010203;
+	uint32_t value = htole32(0xAB010203);
 	LY_ERR err;
 
+	/* Note that this api expects 'value' to be in little-endian form */
 	err = lyd_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
 			       LYD_NEW_PATH_UPDATE, NULL);
 	assert(err == LY_SUCCESS);


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed byte-order handling in northbound tests and updated .gitignore for test binaries. These changes ensure tests run correctly on little-endian architectures and properly ignore generated test files.

**Bug Fixes**
- Updated `test_oper_data.c` to use little-endian byte order with libyang API to fix test failures on LE architectures.
- Added clarifying comment about the API's expectation for little-endian input.

**Chores**
- Added `/lib/northbound/test_oper_exists` to .gitignore to exclude the northbound unit-test binary.

<!-- End of auto-generated description by mrge. -->

